### PR TITLE
Missing versioning in package throws error in already flattened directory

### DIFF
--- a/lib/flatten.js
+++ b/lib/flatten.js
@@ -55,8 +55,8 @@ module.exports = function(dir, options, callback) {
 
           try {
             var packageJson = require(modules[i]);
-            currentData.name = packageJson.name;
-            currentData.version = packageJson.version;
+            currentData.name = packageJson.name || currentData.dirname;
+            currentData.version = packageJson.version || '0.0.0';
           }
           catch(err) {
             return callback(err);


### PR DESCRIPTION
When I ran flatten-packages in an already flattened directory, I got the following error:

```
PS D:\Project> flatten-packages
processing directory D:\Project
there are 210 total packages

C:\Users\teltploek\AppData\Roaming\npm\node_modules\flatten-packages\lib\flatten.js:89
ole.log(' duplicate:'.magenta, currentData.name, currentData.version.cyan, 'ex
                                                                    ^
TypeError: Cannot read property 'cyan' of undefined
    at C:\Users\teltploek\AppData\Roaming\npm\node_modules\flatten-packages\lib\flatten.js:89:89
    at C:\Users\teltploek\AppData\Roaming\npm\node_modules\flatten-packages\lib\flatten.js:198:31
    at C:\Users\teltploek\AppData\Roaming\npm\node_modules\flatten-packages\lib\flatten.js:198:31
    at C:\Users\teltploek\AppData\Roaming\npm\node_modules\flatten-packages\lib\flatten.js:198:31
    at C:\Users\teltploek\AppData\Roaming\npm\node_modules\flatten-packages\lib\flatten.js:198:31
    at C:\Users\teltploek\AppData\Roaming\npm\node_modules\flatten-packages\lib\flatten.js:198:31
    at C:\Users\teltploek\AppData\Roaming\npm\node_modules\flatten-packages\lib\flatten.js:198:31
    at C:\Users\teltploek\AppData\Roaming\npm\node_modules\flatten-packages\lib\flatten.js:198:31
    at C:\Users\teltploek\AppData\Roaming\npm\node_modules\flatten-packages\lib\flatten.js:198:31
    at C:\Users\teltploek\AppData\Roaming\npm\node_modules\flatten-packages\lib\flatten.js:214:27
```

The reason for the error is, that a package has no version information in its package.json. The package garply has a package.json containing:

```
{
    "main" : "./lib"
}
```

This pull-request should take care of this issue.
